### PR TITLE
Add player spawned check

### DIFF
--- a/lib/ship_web/live/game_live.ex
+++ b/lib/ship_web/live/game_live.ex
@@ -20,9 +20,11 @@ defmodule ShipWeb.GameLive do
       |> assign_loading_state()
 
     if connected?(socket) do
-      ECSx.ClientEvents.add(player.id, :spawn_ship)
-      # The first load will now have additional responsibilities
-      send(self(), :first_load)
+      unless PlayerSpawned.exists?(player.id) do
+        ECSx.ClientEvents.add(player.id, :spawn_ship)
+        # The first load will now have additional responsibilities
+        send(self(), :first_load)
+      end
     end
 
     {:ok, socket}


### PR DESCRIPTION
This adds an extra check to see if the player has already spawned before firing the spawn ship event. This will prevent the error that an entity with that same ID has already been added in case the player decides to refresh the page.